### PR TITLE
Check if `editor` is defined before trying to use it

### DIFF
--- a/lib/commands.js
+++ b/lib/commands.js
@@ -117,6 +117,7 @@ export default class Commands {
       }
     }
     const editor = atom.workspace.getActiveTextEditor()
+    if (!editor) return
     const editorElement = atom.views.getView(editor)
     const subscriptions = new CompositeDisposable()
     if (subscription) {
@@ -174,6 +175,7 @@ export default class Commands {
       }
     }
     const editor = atom.workspace.getActiveTextEditor()
+    if (!editor) return
     const editorElement = atom.views.getView(editor)
     const subscriptions = new CompositeDisposable()
     const shouldProcess = await this.shouldHighlightsShow(editor)


### PR DESCRIPTION
Basically the same as https://github.com/atom/atom/issues/12702 -- if a `TextEditor` isn't a `PaneItem`, `atom.workspace.getActiveTextEditor()` won't return it, which in turn breaks the following code.

This happens when using the [ink console](https://github.com/JunoLab/atom-ink); I suppose we could just use mini-editors, but intentions still shouldn't break imho.