### PR TITLE
fix: unify the keybindings for different os

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,8 @@ Intentions is a base package that provides an easy-to-use API to show intentions
 
 #### Usage
 
-The default keybinding on OSX to trigger list is `ctrl` + `enter`. If you want to trigger intentions highlights,
-press `alt`.
-
-The default keybinding on Windows and Linux to trigger list is `alt` + `enter`. If you want to trigger intentions
-highlights press `ctrl`.
+- Use <kbd>ALT</kbd>+<kbd>ENTER</kbd> to open the intensions list and press <kbd>ENTER</kbd> (or select by mouse) to choose the action.
+- To see the all available actions hold <kbd>CTRL</kbd> (<kbd>⌘</kbd> on macOS).
 
 #### APIs
 

--- a/keymaps/intentions.json
+++ b/keymaps/intentions.json
@@ -1,11 +1,12 @@
 {
   ".platform-darwin atom-text-editor:not([mini])": {
-    "ctrl-enter": "intentions:show",
-    "alt": "intentions:highlight"
+    "cmd": "intentions:highlight"
   },
   ".platform-win32 atom-text-editor:not([mini]), .platform-linux atom-text-editor:not([mini])": {
-    "alt-enter": "intentions:show",
     "ctrl": "intentions:highlight"
+  },
+  "atom-text-editor:not([mini])": {
+    "alt-enter": "intentions:show"
   },
   "atom-text-editor.intentions-list:not([mini])": {
     "enter": "intentions:confirm"


### PR DESCRIPTION
BREAKING CHANGE keybindings on macOS is now the same as other operating systems


Fixes #86 