### PR TITLE
chore: add Vim bindings instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,13 @@ Intentions is a base package that provides an easy-to-use API to show intentions
 
 - Use <kbd>ALT</kbd>+<kbd>ENTER</kbd> to open the intensions list and press <kbd>ENTER</kbd> (or select by mouse) to choose the action.
 - To see the all available actions hold <kbd>CTRL</kbd> (<kbd>⌘</kbd> on macOS).
+- `vim-mode-plus` users can add these keymap entries to use <kbd>j</kbd> and <kbd>k</kbd> to navigate the actions list
+```cson
+'atom-text-editor.intentions-list:not([mini])':
+  'enter': 'intentions:confirm'
+  'j': 'core:move-up'
+  'k': 'core:move-down'
+```
 
 ![intentions-list](https://user-images.githubusercontent.com/16418197/122294624-dd304100-cebd-11eb-9232-d015cde1516f.gif)
 

--- a/README.md
+++ b/README.md
@@ -8,15 +8,16 @@ Intentions is a base package that provides an easy-to-use API to show intentions
 
 - Use <kbd>ALT</kbd>+<kbd>ENTER</kbd> to open the intensions list and press <kbd>ENTER</kbd> (or select by mouse) to choose the action.
 - To see the all available actions hold <kbd>CTRL</kbd> (<kbd>⌘</kbd> on macOS).
-- `vim-mode-plus` users can add these keymap entries to use <kbd>j</kbd> and <kbd>k</kbd> to navigate the actions list
+
+![intentions-list](https://user-images.githubusercontent.com/16418197/122294624-dd304100-cebd-11eb-9232-d015cde1516f.gif)
+
+[`vim-mode-plus`](https://github.com/t9md/atom-vim-mode-plus/) users can add these keymap entries to use <kbd>j</kbd> and <kbd>k</kbd> to navigate the actions list
 ```cson
 'atom-text-editor.intentions-list:not([mini])':
   'enter': 'intentions:confirm'
   'j': 'core:move-up'
   'k': 'core:move-down'
 ```
-
-![intentions-list](https://user-images.githubusercontent.com/16418197/122294624-dd304100-cebd-11eb-9232-d015cde1516f.gif)
 
 **Note**: This package does not work on older Atoms. You should install the **latest version of Atom** from:
 https://atom.io/


### PR DESCRIPTION
As the movement commands aren't specific to intentions, it took reading the source to find the `core:move-*` commands. Adding to the README will help many users get up and running.